### PR TITLE
Add OCaml >= 4.08 bounds

### DIFF
--- a/ansifmt.opam
+++ b/ansifmt.opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/qexat/ansifmt"
 bug-reports: "https://github.com/qexat/ansifmt/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,6 @@
  (synopsis "A simple, lightweight library for ANSI formatting")
  (description
   "A simple, lightweight library for ANSI formatting with powerful features such as a tokenization-based system for pretty-printing code in the terminal.")
- (depends ocaml)
+ (depends (ocaml (>= "4.08")))
  (tags
   ("ansi" "formatting" "pretty-printing" "terminal")))


### PR DESCRIPTION
To automatically populate bounds for `opam-repository` releases.